### PR TITLE
Fix error when not all identifiers exist

### DIFF
--- a/R/oc_lookup.R
+++ b/R/oc_lookup.R
@@ -7,7 +7,7 @@ oc_2ids_template <- function(template_string, id_name) {
     df <- tmp[-grep('\\.type', names(tmp))]
     names(df) <- gsub("\\.value", "", names(df))
     names(df)[1] <- id_name
-    df <- df[, c("doi", "pmid", "pmcid", "paper")]
+    df <- df[, names(df) %in% c("doi", "pmid", "pmcid", "paper")]
     return(df)
   }
 }


### PR DESCRIPTION
The previous code assumed every article has all four of the `pmcid`, `doi`, `pmid` and `paper` and throws an error if any is missing. My fix relaxes this assumption and retrieves these columns from the data frame **if they exist**.

See https://github.com/ropenscilabs/citecorp/issues/1#issuecomment-545814584